### PR TITLE
Update S-Bus to PPM conversion logic

### DIFF
--- a/main.c
+++ b/main.c
@@ -55,7 +55,6 @@ volatile uint16_t ledpause = 0x2FFF;
 #if PPM_OUTPUT == TRUE
 ISR(TIMER1_COMPB_vect)
 {
-	asm("sei");
 	isr_channel_number++;
 	if( isr_channel_number >= (PPMCH + 1) ) 
 	{

--- a/main.c
+++ b/main.c
@@ -340,8 +340,13 @@ int main(void)
 				}
 
 #if PPM_OUTPUT == TRUE						
-				cli();
+				unsigned int temp_isr_channel_pw[(PPMCH +1)];
 				uint8_t i=0;
+
+				/*
+				 * Floating point math is slow, so perform computations before
+				 * disabling interrupts.
+				 */
 				for(i=0;i<PPMCH;i++)
 				{
 					/*
@@ -350,10 +355,15 @@ int main(void)
 					 * See https://gist.github.com/prattmic/8857047
 					 */
 					uint16_t pw = 0.624731*channels[i] + 880.561511;
-					isr_channel_pw[i] = ((((F_CPU/1000) * pw)/1000)/TIMER1_PRESCALER);
+					temp_isr_channel_pw[i] = ((((F_CPU/1000) * pw)/1000)/TIMER1_PRESCALER);
+				}
+
+				cli();
+				for (i = 0; i < PPMCH; i++) {
+					isr_channel_pw[i] = temp_isr_channel_pw[i];
 				}
 				sei();
-#endif					
+#endif
 
 				//wenn kein failsafe dann output senden
 				if((sbus_bytes[23] & 8) == 0)

--- a/main.c
+++ b/main.c
@@ -345,7 +345,12 @@ int main(void)
 				uint8_t i=0;
 				for(i=0;i<PPMCH;i++)
 				{
-					uint16_t pw = 1000 + (channels[i]/1.9) - 48;
+					/*
+					 * From linear regression of 7 PWM samples from
+					 * 1100..1940us. R^2 = 0.999999.
+					 * See https://gist.github.com/prattmic/8857047
+					 */
+					uint16_t pw = 0.624731*channels[i] + 880.561511;
 					isr_channel_pw[i] = ((((F_CPU/1000) * pw)/1000)/TIMER1_PRESCALER);
 				}
 				sei();


### PR DESCRIPTION
First, update the formula used for converting S-Bus values to PPM pulse widths.  Based on measurements on a Saleae Logic, the pulse widths of the board PPM output did not match the PWM outputs from a Futaba receiver.  So, S-Bus data and PWM pulse widths were captured for various outputs.  These data were used to perform a linear regression, creating a new conversion function, with an R^2 error of 0.999.

The S-Bus parsing and regression code can be found along with the raw S-Bus and pulse width data can be found at: https://gist.github.com/prattmic/8857047

Also, the floating point arithmetic performed for the conversion is very slow (>750us, if some of the benchmarks are to be believed, though I didn't measure).  Performing these computations while interrupts are disabled delays handling of the PPM timer comparator interrupt.  Ultimately, this results in glitches on the PPM output, most notably, doubled pulses once every second or so (I forgot to screencap the waveform, sorry).  By performing the computations while interrupts are enabled, this can be avoided.
